### PR TITLE
Basic expression parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/dev/jensderuiter/websk/Main.java
+++ b/src/main/java/dev/jensderuiter/websk/Main.java
@@ -16,6 +16,7 @@ public final class Main extends JavaPlugin {
     private SkriptAddon addon;
     private static SkriptAdapter skriptAdapter;
     public static Webserver webserver = null;
+    public static boolean use26;
 
     @Override
     public void onEnable() {
@@ -29,6 +30,7 @@ public final class Main extends JavaPlugin {
         // This class is from 2.6-alpha1 and +
         final boolean use26 = ReflectionUtils.classExist("ch.njol.skript.conditions.CondIsPluginEnabled");
         skriptAdapter = use26 ? new SkriptV2_6() : new SkriptV2_3();
+        Main.use26 = use26;
     }
 
     public static SkriptAdapter getSkriptAdapter() {

--- a/src/main/java/dev/jensderuiter/websk/skript/expression/LoopValue.java
+++ b/src/main/java/dev/jensderuiter/websk/skript/expression/LoopValue.java
@@ -1,0 +1,53 @@
+package dev.jensderuiter.websk.skript.expression;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import dev.jensderuiter.websk.skript.factory.ServerEvent;
+import dev.jensderuiter.websk.skript.type.Request;
+import dev.jensderuiter.websk.utils.adapter.SkriptAdapter;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class LoopValue extends SimpleExpression<Object> {
+
+    public static Object lastEntity;
+
+    static {
+        Skript.registerExpression(
+                LoopValue.class,
+                Object.class,
+                ExpressionType.SIMPLE,
+                "[the] loop( |-)entity"
+        );
+    }
+
+    @Override
+    protected Object @NotNull [] get(@NotNull Event event) {
+        return new Object[] {lastEntity};
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<?> getReturnType() {
+        return Object.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event event, boolean b) {
+        return "loop-value";
+    }
+
+    @Override
+    public boolean init(Expression<?> @NotNull [] expressions, int i, @NotNull Kleenean kleenean, SkriptParser.@NotNull ParseResult parseResult) {
+        return SkriptAdapter.getInstance().isCurrentEvents(ServerEvent.class);
+    }
+}

--- a/src/main/java/dev/jensderuiter/websk/skript/factory/ServerFactory.java
+++ b/src/main/java/dev/jensderuiter/websk/skript/factory/ServerFactory.java
@@ -18,7 +18,8 @@ public class ServerFactory {
 
     public static final SectionValidator webValidator = new SectionValidator()
             .addEntry("port", false)
-            .addSection("on request", false);
+            .addSection("on request", false)
+            .addSection("on error", true);
 
     public ServerObject parse(SectionNode node) {
 
@@ -36,13 +37,14 @@ public class ServerFactory {
         }
 
         final SectionNode onRequest = (SectionNode) node.get("on request");
+        final @Nullable SectionNode onError = (SectionNode) node.get("on error");
 
         // This should never happen btw, but it's to avoid NPE
         if (onRequest == null)
             return null;
 
         final @Nullable ServerObject obj = new ServerObject(port,
-                ScriptLoader.loadItems(onRequest)
+                ScriptLoader.loadItems(onRequest), (onError == null ? null : ScriptLoader.loadItems(onError))
         );
 
         try {

--- a/src/main/java/dev/jensderuiter/websk/skript/factory/ServerObject.java
+++ b/src/main/java/dev/jensderuiter/websk/skript/factory/ServerObject.java
@@ -5,6 +5,7 @@ import ch.njol.skript.lang.TriggerItem;
 import dev.jensderuiter.websk.skript.effect.EffReturn;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -14,12 +15,14 @@ public class ServerObject {
 
     private final int port;
     private final List<TriggerItem> onRequest;
+    private final List<TriggerItem> onError;
 
-    public ServerObject(int port, List<TriggerItem> onRequest) {
+    public ServerObject(int port, List<TriggerItem> onRequest, List<TriggerItem> onError) {
         if (CURRENT_SERVER != null)
             throw new IllegalStateException("You cannot create ServerObject if another instance is already enabled.");
         this.port = port;
         this.onRequest = onRequest;
+        this.onError = onError == null ? new ArrayList<>() : onError;
         CURRENT_SERVER = this;
     }
 
@@ -33,5 +36,9 @@ public class ServerObject {
 
     public List<TriggerItem> getOnRequest() {
         return onRequest;
+    }
+
+    public List<TriggerItem> getOnError() {
+        return onError;
     }
 }

--- a/src/main/java/dev/jensderuiter/websk/utils/SkriptUtils.java
+++ b/src/main/java/dev/jensderuiter/websk/utils/SkriptUtils.java
@@ -1,0 +1,62 @@
+package dev.jensderuiter.websk.utils;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SyntaxElement;
+import ch.njol.skript.lang.SyntaxElementInfo;
+import ch.njol.skript.log.ParseLogHandler;
+import ch.njol.skript.log.SkriptLogger;
+import dev.jensderuiter.websk.Main;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Iterator;
+
+public final class SkriptUtils {
+
+    /**
+     * Original code from SkriptLang team, I just changed how the SkriptParser work with Expression.
+     * @author SkriptLang team
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public static <T extends SyntaxElement> T parseExpression(String expr, Iterator<? extends SyntaxElementInfo<? extends T>> source, @Nullable String defaultError) {
+        expr = "" + expr.trim();
+        if (expr.isEmpty()) {
+            Skript.error(defaultError);
+            return null;
+        } else {
+            ParseLogHandler log = SkriptLogger.startParseLogHandler();
+
+            T var5;
+            try {
+                final SkriptParser parser = new SkriptParser(expr);
+                final T e;
+                try {
+                    final Method method = parser
+                            .getClass()
+                            .getDeclaredMethod("parse", Iterator.class);
+                    method.setAccessible(true);
+                    e = (T) method.invoke(parser, source);
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                    return null;
+                }
+                if (e == null) {
+                    log.printError(defaultError);
+                    var5 = null;
+                    return var5;
+                }
+
+                log.printLog();
+                var5 = e;
+            } finally {
+                log.stop();
+            }
+
+            return var5;
+        }
+    }
+
+}

--- a/src/main/java/dev/jensderuiter/websk/utils/SkriptUtils.java
+++ b/src/main/java/dev/jensderuiter/websk/utils/SkriptUtils.java
@@ -4,16 +4,23 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.SyntaxElement;
 import ch.njol.skript.lang.SyntaxElementInfo;
+import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.log.ParseLogHandler;
 import ch.njol.skript.log.SkriptLogger;
-import dev.jensderuiter.websk.Main;
+import ch.njol.skript.variables.Variables;
+import ch.njol.util.StringUtils;
+import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class SkriptUtils {
+
+    private static final Pattern varPattern = Pattern.compile("%[\\w-_:*]+%");
 
     /**
      * Original code from SkriptLang team, I just changed how the SkriptParser work with Expression.
@@ -21,7 +28,11 @@ public final class SkriptUtils {
      */
     @Nullable
     @SuppressWarnings("unchecked")
-    public static <T extends SyntaxElement> T parseExpression(String expr, Iterator<? extends SyntaxElementInfo<? extends T>> source, @Nullable String defaultError) {
+    public static <T extends SyntaxElement> T parseExpression(
+            String expr,
+            Iterator<? extends SyntaxElementInfo<? extends T>> source,
+            @Nullable String defaultError,
+            Event event) {
         expr = "" + expr.trim();
         if (expr.isEmpty()) {
             Skript.error(defaultError);
@@ -29,11 +40,38 @@ public final class SkriptUtils {
         } else {
             ParseLogHandler log = SkriptLogger.startParseLogHandler();
 
-            T var5;
+            final Matcher varMatcher = varPattern.matcher(expr);
+            final boolean onlyVariable = expr.startsWith("\"%") && expr.endsWith("%\"");
+
+            final T var5;
             try {
+
+                String mainContent = null;
+                while (varMatcher.find()) {
+                    final String varName = varMatcher.group(0).replaceAll("%", "");
+                    final Object value = Variables.getVariable(varName.replaceFirst("_", ""),
+                            event, varName.startsWith("_"));
+                    String content;
+                    try {
+                        content = StringUtils.join(((Map<?, ?>) value).values(), ", ");
+                    } catch (ClassCastException ex) {
+                        content = value.toString();
+                    } catch (NullPointerException ex) {
+                        content = "<none>";
+                    }
+                    mainContent = content;
+                    expr = replaceGroup(varPattern.toString(),
+                            expr, 0, content);
+                }
+
+                if (onlyVariable)
+                    return mainContent == null ? null : (T) new SimpleLiteral<>(mainContent, false);
+
                 final SkriptParser parser = new SkriptParser(expr);
                 final T e;
                 try {
+
+                    // The parse method is private
                     final Method method = parser
                             .getClass()
                             .getDeclaredMethod("parse", Iterator.class);
@@ -59,4 +97,14 @@ public final class SkriptUtils {
         }
     }
 
+    public static String replaceGroup(String regex, String source, int groupToReplace, String replacement) {
+        return replaceGroup(regex, source, groupToReplace, 1, replacement);
+    }
+
+    public static String replaceGroup(String regex, String source, int groupToReplace, int groupOccurrence, String replacement) {
+        Matcher m = Pattern.compile(regex).matcher(source);
+        for (int i = 0; i < groupOccurrence; i++)
+            if (!m.find()) return source; // pattern not met, may also throw an exception here
+        return new StringBuilder(source).replace(m.start(groupToReplace), m.end(groupToReplace), replacement).toString();
+    }
 }

--- a/src/main/java/dev/jensderuiter/websk/utils/parser/ParserFactory.java
+++ b/src/main/java/dev/jensderuiter/websk/utils/parser/ParserFactory.java
@@ -1,0 +1,161 @@
+package dev.jensderuiter.websk.utils.parser;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.variables.Variables;
+import ch.njol.util.NonNullPair;
+import ch.njol.util.StringUtils;
+import dev.jensderuiter.websk.skript.expression.LoopValue;
+import dev.jensderuiter.websk.utils.SkriptUtils;
+import org.bukkit.event.Event;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Sky
+ */
+public class ParserFactory {
+
+    private final Pattern codePattern = Pattern.compile("\\{\\{([^}]+)}}", Pattern.DOTALL);
+    private final Pattern echoPattern = Pattern.compile("show (.+)");
+    private final Pattern forPattern = Pattern.compile("(for|loop) (.+)");
+    private final Pattern endLoopPattern = Pattern.compile("\\{\\{\\/([^}]+)}}");
+    private static final ParserFactory instance = new ParserFactory();
+
+    public static ParserFactory get() {
+        return instance;
+    }
+
+    private boolean inLoop = false;
+    public NonNullPair<List<String>, String> parse(String content, Event event, boolean subGroup) {
+        if (content.isEmpty())
+            return new NonNullPair<>(new ArrayList<>(), "");
+
+        final List<String> errors = new ArrayList<>();
+
+        final Matcher codeMatcher = codePattern.matcher(content);
+
+        while (codeMatcher.find()) {
+            final String data = codeMatcher.group();
+            final String code = codeMatcher.group(1);
+            final String formattedCode = code.replaceAll("\\t", "").replaceAll( " {4}", "");
+
+            // Matchers
+            final Matcher echoMatcher = echoPattern.matcher(formattedCode);
+            final Matcher loopMatcher = forPattern.matcher(formattedCode);
+
+            if (formattedCode.startsWith("#")) { // Commentary node
+                content = content.replace(data, "");
+            } else if (echoMatcher.find()) { // Echo pattern
+                final String expr = echoMatcher.group(1);
+                final Expression<?> expression = SkriptUtils.parseExpression(expr, null, event);
+                if (expression == null) {
+                    errors.add("Cannot understand this expression: '" + expr + "'");
+                    continue;
+                }
+                String value;
+                try {
+                    try {
+                        value = expression.isSingle() ? expression.getSingle(event).toString() :
+                                StringUtils.join(expression.getArray(event), ", ");
+                    } catch (Exception ex) {
+                        value = "<none>";
+                    }
+                } catch (NullPointerException ex) {
+                    value = "<none>";
+                }
+                content = content.replace(data, value);
+
+            } else if (loopMatcher.find()) { // Start loop
+
+                final String expr = loopMatcher.group(2);
+
+                final Expression<?> expression = SkriptUtils.parseExpression(expr, null, event);
+                Object[] values;
+                if (expression == null) {
+                    values = parseVariableList(expr, event);
+                } else {
+                    if (expression.isSingle()) {
+                        errors.add("The '"+expr+"' return a single value and can therefore not be looped.");
+                        continue;
+                    }
+                    values = expression.getArray(event);
+                }
+
+                /* if (inLoop) {
+                    errors.add("Starting a loop '"+varName+"', but was already in before. You can't have two loop in the same section.");
+                    continue;
+                }
+
+                inLoop = true; */
+                final Matcher endLoopMatcher = endLoopPattern.matcher(content);
+                if (!endLoopMatcher.find()) {
+                    errors.add("Unable to find end of the '"+expr+"' loop.");
+                    continue;
+                }
+                if (subGroup)
+                    System.out.println("Content: " + content);
+                final String codeBetween = content
+                        .split(escape(data))[1]
+                        .split(escape("{{/" + expr + "}}"))[0];
+
+                String codeInside = "";
+                for (Object value : values) {
+                    LoopValue.lastEntity = value;
+                    final NonNullPair<List<String>, String> parseResult = parse(codeBetween, event, true);
+                    errors.addAll(parseResult.getFirst());
+                    codeInside += parseResult.getSecond();
+                }
+                content = content.replace(data + codeBetween, codeInside);
+
+            } else {
+
+                if (formattedCode.startsWith("/")) {
+                    /* if (!inLoop)
+                        errors.add("Closing '"+formattedCode+"' loop without being in it.");
+                    inLoop = false; */
+                    content = content.replace(data, "");
+
+                } else {
+                    final String value = parseVariable(formattedCode, event);
+                    content = content.replace(data, value);
+                }
+
+            }
+        }
+
+        return new NonNullPair<>(errors, content);
+    }
+
+    private final Pattern SPECIAL_REGEX_CHARS = Pattern.compile("[{}()\\[\\].+*?^$\\\\|]");
+    public String escape(String str) {
+        return SPECIAL_REGEX_CHARS.matcher(str).replaceAll("\\\\$0");
+    }
+
+    public Object[] parseVariableList(String varName, Event event) {
+        final Object value = Variables.getVariable(varName, event, true);
+        if (!(value instanceof Map))
+            return new Object[0];
+        return ((Map<?, ?>) value).values().toArray();
+    }
+
+    public String parseVariable(String varName, Event event) {
+        final Object value = Variables.getVariable(varName, event, true);
+        Object str;
+        try {
+            str = ((Map<?, ?>) value)
+                    .values()
+                    .stream()
+                    .map(Object::toString)
+                    .toArray(String[]::new);
+        } catch (ClassCastException ex) {
+            str = value.toString();
+        } catch (NullPointerException ex) {
+            str = "<none>";
+        }
+        return str.toString();
+    }
+}


### PR DESCRIPTION
This pull request offer the way to parse expression directly in a template file:

```applescript
define webserver:
	port: 8000
	on request:
		set {_version} to skript version
		return the template file "property.html"
```

With template:
```html
<!DOCTYPE html>
<html lang="en">
<head>
	<meta charset="UTF-8">
	<meta http-equiv="X-UA-Compatible" content="IE=edge">
	<meta name="viewport" content="width=device-width, initial-scale=1.0">
	<title>Document</title>
</head>
<body>
	<h1>
		Expression var example
	</h1>
	<p>{{version}}
	{{show avatar of bot named "bot"}}
	{{show size of members of guild with id "818182471140114432"}}</p>
</body>
</html>
```

Show:
![image](https://user-images.githubusercontent.com/50667548/139577886-fee60329-5027-4ce8-97ba-42002fd59531.png)

I currently set the special mark as `show`, but you can change it at any time as you like ^^
Moreover, it should parse expression according to the current event, which means the local variables and the event values will be set and usable.