### PR TITLE
Added way to return a custom code & headers

### DIFF
--- a/src/main/java/dev/jensderuiter/websk/skript/effect/EffReturn.java
+++ b/src/main/java/dev/jensderuiter/websk/skript/effect/EffReturn.java
@@ -7,6 +7,7 @@ import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
 import dev.jensderuiter.websk.skript.factory.ServerEvent;
+import dev.jensderuiter.websk.skript.type.Header;
 import dev.jensderuiter.websk.utils.adapter.SkriptAdapter;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -17,12 +18,16 @@ public class EffReturn extends Effect {
     static {
         Skript.registerEffect(
                 EffReturn.class,
-                "return %string%"
+                "return %string% [with [the] code %-number%] [with [the] [header] %-webheaders%]"
         );
     }
 
     private Expression<String> input;
+    private Expression<Header> exprHeaders;
+    private Expression<Number> exprCode;
     public static String value = null;
+    public static Number code = null;
+    public static Header[] headers = null;
 
     @Override
     protected void execute(@NotNull Event e) { }
@@ -30,12 +35,14 @@ public class EffReturn extends Effect {
     @Override
     protected @Nullable TriggerItem walk(@NotNull Event e) {
         value = input.getSingle(e);
+        headers = exprHeaders.getArray(e);
+        code = exprCode.getSingle(e);
         return null;
     }
 
     @Override
     public @NotNull String toString(@Nullable Event e, boolean b) {
-        return "return " + input.toString(e, b);
+        return "return " + input.toString(e, b) + (exprHeaders != null ? " with headers " + exprHeaders.toString(e, b) : "");
     }
 
     @Override
@@ -43,6 +50,8 @@ public class EffReturn extends Effect {
         if (!SkriptAdapter.getInstance().isCurrentEvents(ServerEvent.class))
             return false;
         input = (Expression<String>) expressions[0];
+        exprCode = (Expression<Number>) expressions[1];
+        exprHeaders = (Expression<Header>) expressions[2];
         return true;
     }
 }

--- a/src/main/java/dev/jensderuiter/websk/skript/expression/NewHeader.java
+++ b/src/main/java/dev/jensderuiter/websk/skript/expression/NewHeader.java
@@ -1,0 +1,58 @@
+package dev.jensderuiter.websk.skript.expression;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import dev.jensderuiter.websk.skript.type.Header;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class NewHeader extends SimpleExpression<Header> {
+
+    static {
+        Skript.registerExpression(
+                NewHeader.class,
+                Header.class,
+                ExpressionType.SIMPLE,
+                "[a] new header with [the] (key|name) %string% [and] with [the] (value|data) %string%"
+        );
+    }
+
+    private Expression<String> exprKey;
+    private Expression<String> exprValue;
+
+    @Override
+    protected Header @NotNull [] get(@NotNull Event e) {
+        final String key = exprKey.getSingle(e);
+        final String value = exprValue.getSingle(e);
+        if (key == null || value == null)
+            return new Header[0];
+        return new Header[] {new Header(key, value)};
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Class<? extends Header> getReturnType() {
+        return Header.class;
+    }
+
+    @Override
+    public @NotNull String toString(@Nullable Event event, boolean b) {
+        return "new header with key " + exprKey.toString(event, b) + " with value " + exprValue.toString(event, b);
+    }
+
+    @Override
+    public boolean init(Expression<?> @NotNull [] expressions, int i, @NotNull Kleenean kleenean, SkriptParser.@NotNull ParseResult parseResult) {
+        exprKey = (Expression<String>) expressions[0];
+        exprValue = (Expression<String>) expressions[1];
+        return true;
+    }
+}

--- a/src/main/java/dev/jensderuiter/websk/skript/type/ClassInfos.java
+++ b/src/main/java/dev/jensderuiter/websk/skript/type/ClassInfos.java
@@ -47,6 +47,11 @@ public class ClassInfos {
                         return toVariableNameString(request);
                     }
                 }));
+
+        Classes.registerClass(new ClassInfo<>(Header.class, "webheader")
+                .user("webheaders?")
+                .name("Header")
+                .description("Represents a request header with a key and a value."));
     }
 
 }

--- a/src/main/java/dev/jensderuiter/websk/skript/type/Header.java
+++ b/src/main/java/dev/jensderuiter/websk/skript/type/Header.java
@@ -1,0 +1,20 @@
+package dev.jensderuiter.websk.skript.type;
+
+public class Header {
+
+    private final String key;
+    private final String value;
+
+    public Header(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/dev/jensderuiter/websk/utils/MultiplyPropertyExpression.java
+++ b/src/main/java/dev/jensderuiter/websk/utils/MultiplyPropertyExpression.java
@@ -1,0 +1,67 @@
+package dev.jensderuiter.websk.utils;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import dev.jensderuiter.websk.utils.adapter.SkriptAdapter;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+/**
+ * By Sky, Olyno & SkriptLang team
+ */
+public abstract class MultiplyPropertyExpression<F, T> extends SimpleExpression<T> {
+
+    public Expression<? extends F> expr;
+
+    protected static <T> void register(final Class<? extends Expression<T>> c, final Class<T> type, final String property, final String fromType) {
+        Skript.registerExpression(c, type, ExpressionType.SIMPLE,
+                "[all] [the] " + property + " of %" + fromType + "%",
+                "[all] [the] %" + fromType + "%'[s] " + property
+        );
+    }
+
+    public abstract @NotNull Class<? extends T> getReturnType();
+
+    protected abstract String getPropertyName();
+
+    protected abstract T[] convert(F t);
+
+    protected Kleenean isDelayed() {
+        return Kleenean.FALSE;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean init(final Expression<?> @NotNull [] expr, final int matchedPattern, final @NotNull Kleenean isDelayed, final SkriptParser.@NotNull ParseResult parseResult) {
+        SkriptAdapter.getInstance().setHasDelayedBefore(isDelayed());
+        this.expr = (Expression<? extends F>) expr[0];
+        return true;
+    }
+
+    @Override
+    protected T @NotNull [] get(@NotNull Event e) {
+        if (expr.getSingle(e) == null)
+            return (T[]) new Object[0];
+        return convert(expr.getSingle(e));
+    }
+
+    @Override
+    public boolean isSingle() {
+        return false;
+    }
+
+    @Override
+    public @NotNull String toString(final @Nullable Event e, final boolean debug) {
+        return "the " + getPropertyName() + " of " + expr.toString(e, debug);
+    }
+
+    public Expression<? extends F> getExpr() {
+        return expr;
+    }
+}

--- a/src/main/java/dev/jensderuiter/websk/web/Webserver.java
+++ b/src/main/java/dev/jensderuiter/websk/web/Webserver.java
@@ -8,6 +8,7 @@ import dev.jensderuiter.websk.Main;
 import dev.jensderuiter.websk.skript.effect.EffReturn;
 import dev.jensderuiter.websk.skript.factory.ServerEvent;
 import dev.jensderuiter.websk.skript.factory.ServerObject;
+import dev.jensderuiter.websk.skript.type.Header;
 import dev.jensderuiter.websk.skript.type.Request;
 import org.bukkit.Bukkit;
 
@@ -16,6 +17,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class Webserver extends Thread {
@@ -75,8 +78,14 @@ public class Webserver extends Thread {
 
 
                 EffReturn.value = null; // We clear the previous value, if set or not
+                EffReturn.headers = null; // We clear the previous value, if set or not
+                EffReturn.code = null; // We clear the previous value, if set or not
                 TriggerItem.walk(object.getOnRequest().get(0), new ServerEvent(this, request, httpExchange));
                 String responseString = EffReturn.value;
+                Number code = EffReturn.code;
+                if (code == null)
+                    code = 200;
+                Header[] customHeaders = EffReturn.headers;
                 if (responseString == null)
                     Skript.warning("You are not retuning anything on from a webserver request!");
 
@@ -86,8 +95,10 @@ public class Webserver extends Thread {
                 if (cookieValues != null) {
                     respHeaders.put("Set-Cookie", cookieValues);
                 }
+                for (Header header : customHeaders)
+                    respHeaders.add(header.getKey(), header.getValue());
                 try {
-                    httpExchange.sendResponseHeaders(200, response.length);
+                    httpExchange.sendResponseHeaders(code.intValue(), response.length);
                     OutputStream out = httpExchange.getResponseBody();
                     out.write(response);
                     out.close();


### PR DESCRIPTION
This PR adds some new features:
* New type `webheader`
* New expression to create a header, with a key ane a value (same as for `XXX: XXX`)
* Return effect now accept custom response code
* Return effect now accept possible custom headers
Which could allow us to do redirection for example, such as:
```applescript
return "hello" with code 301 with new header with key "Location" with value "https://google.fr/"
```