### PR TITLE
🐛 Fix error while exporting file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,17 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>module-info.class</exclude>
+                                <exclude>META-INF/*.MF</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration> 
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
Fixed errors about ```module-info.class``` and ```META-INF.MF``` copies while exporting.
**Tested with clean install**