### PR TITLE
🐛 Fixed showing error in console.

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,9 @@
+main: dev.jensderuiter.websk.Main
 name: WebSK
 version: '${project.version}'
-main: dev.jensderuiter.websk.Main
-depend: [ Skript ]
 description: Run a website using Skript
 author: jensjeflensje
+api-version: 1.13
+
+depend: [ Skript ]
+prefix: WebSK


### PR DESCRIPTION
In console we had warning:
```Legacy plugin WebSK v2.1 does not specify an api-version.```

I added prefix, i formated it, i added api-version. Small PR