### PR TITLE
More options in return statement

### DIFF
--- a/src/main/java/dev/jensderuiter/websk/skript/effect/EffReturn.java
+++ b/src/main/java/dev/jensderuiter/websk/skript/effect/EffReturn.java
@@ -18,7 +18,7 @@ public class EffReturn extends Effect {
     static {
         Skript.registerEffect(
                 EffReturn.class,
-                "return %string% [with [the] code %-number%] [with [the] [header] %-webheaders%]"
+                "return [the] [template] [file] %string% [with [the] code %-number%] [with [the] [header] %-webheaders%]"
         );
     }
 


### PR DESCRIPTION
You can now type:
`return the file`
`return file`
`return template file`
`return template`
etc.