### PR TITLE
Fix HEAD request!

### DIFF
--- a/src/main/java/dev/jensderuiter/websk/web/Webserver.java
+++ b/src/main/java/dev/jensderuiter/websk/web/Webserver.java
@@ -137,6 +137,13 @@ public class Webserver extends Thread {
                         respHeaders.add(header.getKey(), header.getValue());
                 }
                 try {
+                    if (httpExchange.getRequestMethod().equals("HEAD")) {
+                        respHeaders.add("Transfer-encoding", "chunked");
+                        httpExchange.getRequestBody().close();
+                        httpExchange.sendResponseHeaders(200, -1);
+                        return;
+                    }
+                    
                     httpExchange.sendResponseHeaders(code.intValue(), response.length);
                     OutputStream out = httpExchange.getResponseBody();
                     out.write(response);


### PR DESCRIPTION
@FreeHands reported that when you send HEAD request, it shows error:
```
[16:45:07 WARN]: java.io.IOException: response headers not sent yet
[16:45:07 WARN]: 	at jdk.httpserver/sun.net.httpserver.PlaceholderOutputStream.checkWrap(ExchangeImpl.java:448)
[16:45:07 WARN]: 	at jdk.httpserver/sun.net.httpserver.PlaceholderOutputStream.write(ExchangeImpl.java:458)
[16:45:07 WARN]: 	at websk-1.2.1.jar//dev.jensderuiter.websk.web.Webserver.lambda$setStringContext$2(Webserver.java:147)
[16:45:07 WARN]: 	at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftTask.run(CraftTask.java:101)
[16:45:07 WARN]: 	at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483)
[16:45:07 WARN]: 	at net.minecraft.server.MinecraftServer.b(MinecraftServer.java:1493)
[16:45:07 WARN]: 	at net.minecraft.server.dedicated.DedicatedServer.b(DedicatedServer.java:446)
[16:45:07 WARN]: 	at net.minecraft.server.MinecraftServer.a(MinecraftServer.java:1417)
[16:45:07 WARN]: 	at net.minecraft.server.MinecraftServer.v(MinecraftServer.java:1193)
[16:45:07 WARN]: 	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:305)
[16:45:07 WARN]: 	at java.base/java.lang.Thread.run(Thread.java:833)
```
I fixed that in this PR